### PR TITLE
feat: respect `logLevel` in the config

### DIFF
--- a/libsoratun/config.go
+++ b/libsoratun/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	PrivateKey Key `json:"privateKey"`
 	// ArcSession holds connection information provided from SORACOM Arc server.
 	ArcSession *ArcSession `json:"arcSessionStatus,omitempty"`
+	// LogLevel specifies logging level, verbose (2), error (1), or silent (0).
+	LogLevel int `json:"logLevel"`
 }
 
 // ArcSession holds SORACOM Arc configurations received from the server.

--- a/libsoratun/tunnel.go
+++ b/libsoratun/tunnel.go
@@ -55,7 +55,7 @@ func newTunnel(config *Config) (*tunnel, error) {
 		return nil, fmt.Errorf("failed to create a tunnel: %w", err)
 	}
 
-	logger := device.NewLogger(2, "(libsoratun) ")
+	logger := device.NewLogger(config.LogLevel, "(libsoratun/tunnel) ")
 
 	dev := device.NewDevice(t, conn.NewDefaultBind(), logger)
 
@@ -77,6 +77,7 @@ endpoint=%s
 		strings.Join(allowedIPs, "\n"),
 	)
 
+	logger.Verbosef("Soracom Arc connection configuration:\n%s", conf)
 	if err := dev.IpcSet(conf); err != nil {
 		return nil, fmt.Errorf("failed to configure device: %w", err)
 	}


### PR DESCRIPTION
This allows users to specify the logging level, whether verbose (2), error (1), or silent (0).

Added verbose log messages such as information about
 JSON configuration received, final Soracom Arc connection configuration, Soracom Unified Endpoint URL, User-Agent header value, HTTP requests and responses dump.
